### PR TITLE
feat: Swallow Tab key events and prevent propagation

### DIFF
--- a/lib/src/controller/quill_controller.dart
+++ b/lib/src/controller/quill_controller.dart
@@ -279,10 +279,8 @@ class QuillController extends ChangeNotifier {
     @experimental bool shouldNotifyListeners = true,
   }) {
     assert(data is String || data is Embeddable || data is Delta);
-    print('#### Replace test');
     if (_suppressNextTab && data is String && data.contains('\t')) {
       _suppressNextTab = false;
-      print('#### Debug print: Dropping the tab');
       return;
     }
 

--- a/lib/src/controller/quill_controller.dart
+++ b/lib/src/controller/quill_controller.dart
@@ -279,7 +279,7 @@ class QuillController extends ChangeNotifier {
     @experimental bool shouldNotifyListeners = true,
   }) {
     assert(data is String || data is Embeddable || data is Delta);
-
+    print('#### Replace test');
     if (_suppressNextTab && data is String && data.contains('\t')) {
       _suppressNextTab = false;
       print('#### Debug print: Dropping the tab');

--- a/lib/src/editor/raw_editor/keyboard_shortcuts/editor_keyboard_shortcuts.dart
+++ b/lib/src/editor/raw_editor/keyboard_shortcuts/editor_keyboard_shortcuts.dart
@@ -79,9 +79,10 @@ class EditorKeyboardShortcuts extends StatelessWidget {
 
   KeyEventResult _onKeyEvent(node, KeyEvent event) {
     final isTab = event.logicalKey == LogicalKeyboardKey.tab;
-
     // Swallow Tab before Quill ever sees it
     if (isTab) {
+      // Tells the controller to ignore the upcoming tab‐insert & selection change
+      controller.suppressNextTabInsert();
       if (event is KeyDownEvent) {
         // blur the editor (hides the mobile keyboard)
         print('## Debug print: Handling tab');

--- a/lib/src/editor/raw_editor/keyboard_shortcuts/editor_keyboard_shortcuts.dart
+++ b/lib/src/editor/raw_editor/keyboard_shortcuts/editor_keyboard_shortcuts.dart
@@ -85,7 +85,7 @@ class EditorKeyboardShortcuts extends StatelessWidget {
       controller.suppressNextTabInsert();
       if (event is KeyDownEvent) {
         // blur the editor (hides the mobile keyboard)
-        print('## Debug print: Handling tab');
+        print('## Debug print: Handling tab new');
         node.unfocus();
         // move focus to the next widget
         FocusManager.instance.primaryFocus?.nextFocus();

--- a/lib/src/editor/raw_editor/keyboard_shortcuts/editor_keyboard_shortcuts.dart
+++ b/lib/src/editor/raw_editor/keyboard_shortcuts/editor_keyboard_shortcuts.dart
@@ -84,7 +84,6 @@ class EditorKeyboardShortcuts extends StatelessWidget {
     if (event is KeyDownEvent && isTab) {
       print('## Debug print: Handling tab');
       // Explicitly blur the editor so the mobile keyboard will hide
-      node.unfocus();
       // Move focus to the next widget
       FocusManager.instance.primaryFocus?.nextFocus();
       return KeyEventResult.handled;

--- a/lib/src/editor/raw_editor/keyboard_shortcuts/editor_keyboard_shortcuts.dart
+++ b/lib/src/editor/raw_editor/keyboard_shortcuts/editor_keyboard_shortcuts.dart
@@ -78,6 +78,15 @@ class EditorKeyboardShortcuts extends StatelessWidget {
   }
 
   KeyEventResult _onKeyEvent(node, KeyEvent event) {
+    final isTab = event.logicalKey == LogicalKeyboardKey.tab;
+    // Swallow Tab before Quill ever sees it
+    if (event is KeyDownEvent && isTab) {
+      // move focus onward
+      FocusManager.instance.primaryFocus?.nextFocus();
+      // stop propagation so it does not insert a tab character
+      return KeyEventResult.handled;
+    }
+
     final onKey = onKeyPressed;
     if (onKey != null) {
       // Find the current node the user is on.
@@ -93,7 +102,6 @@ class EditorKeyboardShortcuts extends StatelessWidget {
       return KeyEventResult.ignored;
     }
 
-    final isTab = event.logicalKey == LogicalKeyboardKey.tab;
     final isSpace = event.logicalKey == LogicalKeyboardKey.space;
     final containsSelection =
         controller.selection.baseOffset != controller.selection.extentOffset;

--- a/lib/src/editor/raw_editor/keyboard_shortcuts/editor_keyboard_shortcuts.dart
+++ b/lib/src/editor/raw_editor/keyboard_shortcuts/editor_keyboard_shortcuts.dart
@@ -83,9 +83,10 @@ class EditorKeyboardShortcuts extends StatelessWidget {
     print('## Debug print: key pressed ${event.logicalKey} / ${event.physicalKey}');
     if (event is KeyDownEvent && isTab) {
       print('## Debug print: Handling tab');
-      // move focus onward
+      // Explicitly blur the editor so the mobile keyboard will hide
+      node.unfocus();
+      // Move focus to the next widget
       FocusManager.instance.primaryFocus?.nextFocus();
-      // stop propagation so it does not insert a tab character
       return KeyEventResult.handled;
     }
 

--- a/lib/src/editor/raw_editor/keyboard_shortcuts/editor_keyboard_shortcuts.dart
+++ b/lib/src/editor/raw_editor/keyboard_shortcuts/editor_keyboard_shortcuts.dart
@@ -80,7 +80,9 @@ class EditorKeyboardShortcuts extends StatelessWidget {
   KeyEventResult _onKeyEvent(node, KeyEvent event) {
     final isTab = event.logicalKey == LogicalKeyboardKey.tab;
     // Swallow Tab before Quill ever sees it
+    print('## Debug print: key pressed ${event.logicalKey} / ${event.physicalKey}');
     if (event is KeyDownEvent && isTab) {
+      print('## Debug print: Handling tab');
       // move focus onward
       FocusManager.instance.primaryFocus?.nextFocus();
       // stop propagation so it does not insert a tab character

--- a/lib/src/editor/raw_editor/keyboard_shortcuts/editor_keyboard_shortcuts.dart
+++ b/lib/src/editor/raw_editor/keyboard_shortcuts/editor_keyboard_shortcuts.dart
@@ -79,13 +79,10 @@ class EditorKeyboardShortcuts extends StatelessWidget {
 
   KeyEventResult _onKeyEvent(node, KeyEvent event) {
     final isTab = event.logicalKey == LogicalKeyboardKey.tab;
-    // Swallow Tab before Quill ever sees it
     if (isTab) {
       // Tells the controller to ignore the upcoming tab‐insert & selection change
       controller.suppressNextTabInsert();
       if (event is KeyDownEvent) {
-        // blur the editor (hides the mobile keyboard)
-        print('## Debug print: Handling tab new');
         node.unfocus();
         // move focus to the next widget
         FocusManager.instance.primaryFocus?.nextFocus();

--- a/lib/src/editor/raw_editor/keyboard_shortcuts/editor_keyboard_shortcuts.dart
+++ b/lib/src/editor/raw_editor/keyboard_shortcuts/editor_keyboard_shortcuts.dart
@@ -79,13 +79,16 @@ class EditorKeyboardShortcuts extends StatelessWidget {
 
   KeyEventResult _onKeyEvent(node, KeyEvent event) {
     final isTab = event.logicalKey == LogicalKeyboardKey.tab;
+
     // Swallow Tab before Quill ever sees it
-    print('## Debug print: key pressed ${event.logicalKey} / ${event.physicalKey}');
-    if (event is KeyDownEvent && isTab) {
-      print('## Debug print: Handling tab');
-      // Explicitly blur the editor so the mobile keyboard will hide
-      // Move focus to the next widget
-      FocusManager.instance.primaryFocus?.nextFocus();
+    if (isTab) {
+      if (event is KeyDownEvent) {
+        // blur the editor (hides the mobile keyboard)
+        print('## Debug print: Handling tab');
+        node.unfocus();
+        // move focus to the next widget
+        FocusManager.instance.primaryFocus?.nextFocus();
+      }
       return KeyEventResult.handled;
     }
 


### PR DESCRIPTION
When using the QuillEditor with a hardware keyboard, pressing the Tab key always inserts a tab/space character into the document.

This breaks standard keyboard focus and traps users inside the editor, making keyboard navigation and accessibility impossible.

Known issue with Flutter Quill:
https://github.com/singerdmx/flutter-quill/issues/1871#event-13249190906

Related Issues
https://github.com/singerdmx/flutter-quill/issues/1871#event-13249190906
https://linear.app/flip/issue/EMPMOB-1082/11211-limited-keyboard-operability-calendar
https://linear.app/flip/issue/ENG-1597/11212-keyboard-focus-traps

Type of Change
 Feature: New functionality without breaking existing features.
